### PR TITLE
Add workflow to detect OCI OCIDs in PRs

### DIFF
--- a/.github/workflows/ocid-check.yml
+++ b/.github/workflows/ocid-check.yml
@@ -1,0 +1,25 @@
+name: Check for OCI OCIDs
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  ocid-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Scan pull request diff for OCIDs
+        shell: bash
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          DIFF=$(git diff ${{ github.event.pull_request.base.sha }}...${{ github.sha }})
+          if echo "$DIFF" | grep -nE 'ocid1\.[a-zA-Z0-9._-]+'; then
+            echo "Error: OCI resource OCID found in pull request diff." >&2
+            exit 1
+          else
+            echo "No OCI resource OCIDs found in pull request diff."
+          fi
+


### PR DESCRIPTION
## Summary
- add a GitHub Action that scans pull request diffs for OCI resource OCIDs

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_685b396a509883258b947cc07d75e6a4